### PR TITLE
fix calculation of rx_rttvar in Process

### DIFF
--- a/pseudotcp.cs
+++ b/pseudotcp.cs
@@ -1904,7 +1904,7 @@ namespace PseudoTcp
                         else
                         {
                             priv.rx_rttvar = (size_t)((3 * priv.rx_rttvar +
-                                Math.Abs((long)(rtt - priv.rx_srtt))) / 4);
+                                Math.Abs((long)((long)rtt - priv.rx_srtt))) / 4);
                             priv.rx_srtt = (7 * priv.rx_srtt + rtt) / 8;
                         }
                         priv.rx_rto = bound(MIN_RTO,


### PR DESCRIPTION
Cast `rtt` to long when calculating `priv.rx_rttvar` in `PseudoTcpSocket.Process()`. Else if `rtt < priv.rx_srtt`, it will be a huge number. This will cause `priv.rx_rto` to quickly go to `MAX_RTO` (60 seconds) causing transmission delays.

The problem appears anticipated by this comment:
```
using gsize = System.UInt32; // it should be 64 for 64 bit platforms...
```
If this is changed to System.UInt64 the `rx_rttvar` calculation is correct. But a lot of other code assumes gsize is 32 bit, also I don't think the platform makes a difference here. Casting to long seems a more direct fix.

Part of the solution for https://github.com/psantosl/p2pcopy/issues/4
